### PR TITLE
Add option (-d) for time/date report

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A summary  of nodes is printed, followed by a summary of MPI  task/thread placem
 Options
 
 -c 1|2|3    report on Cartesian communicator with given number of dimensions
+-d          report start and end time/date
 -r          use "reorder" true in MPI_Create_create() (when using -c)
 -s seconds  wait for given number of seconds before exiting with MPI_Finalize().
             This can be useful to prevent immediate exit of the application.


### PR DESCRIPTION
Produce a string, e.g.,
```
xthi_mpi_mp start time at root: Wed Apr 19 16:36:46 2023
```
at the start and end of execution.